### PR TITLE
Log.panic when Call throws a runtime error.

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -1,8 +1,6 @@
 package lua
 
-import (
-	"runtime"
-)
+import "log"
 
 func (l *State) push(v value) {
 	l.stack[l.top] = v
@@ -403,7 +401,7 @@ func (l *State) throw(errorCode Status) {
 			if l.global.panicFunction != nil {
 				l.global.panicFunction(l)
 			}
-			runtime.Goexit() // TODO use log.Panicln() instead, to log an error?
+			log.Panicf("Uncaught Lua error: %v", errorCode)
 		}
 	}
 }


### PR DESCRIPTION
As discussed, prints a message to the console and panic, instead of silently killing the goroutine.

r: @fbogsany 
cc: @Shopify/performance 
