### PR TITLE
Returns basic Go types instead of nil.

### DIFF
--- a/lua.go
+++ b/lua.go
@@ -751,8 +751,8 @@ func ToThread(l *State, index int) *State {
 }
 
 // ToValue convertes the value at `index` into a generic Go interface{}.  The
-// value can be a userdata, a table, a thread, a function, or Go string, bool,
-// uint, int or float64 types. Otherwise, the function returns nil.
+// value can be a userdata, a table, a thread, a function, or Go string, bool
+// or float64 types. Otherwise, the function returns nil.
 //
 // Different objects will give different values.  There is no way to convert
 // the value back into its original value.
@@ -763,12 +763,7 @@ func ToThread(l *State, index int) *State {
 func ToValue(l *State, index int) interface{} {
 	v := l.indexToValue(index)
 	switch v := v.(type) {
-	case string, uint, int, float64, bool:
-	case *table:
-	case *luaClosure:
-	case *goClosure:
-	case *goFunction:
-	case *State:
+	case string, float64, bool, *table, *luaClosure, *goClosure, *goFunction, *State:
 	case *userData:
 		return v.data
 	default:


### PR DESCRIPTION
r: @fbogsany 
## Problem

Since `ToValue` is only used for integration with Go, it's most convenient if Go types that can be `Push` into the VM can also be returned using `ToValue`.  I believe all the basic Go types pushable to lua are `string`, `bool`, `int`, `uint` and `float64`.

For instance, in a test harness exposing `notequals` function to Lua code:

``` go
func isNotEqual(t *testing.T) lua.Function {
    return func(l *lua.State) int {
        name := lua.CheckString(l, 1)
        want := lua.ToValue(l, 2)
        got := lua.ToValue(l, 3)

        if reflect.DeepEqual(want, got) {
            t.Errorf("%s: dont want `%#v` but got it (%#v)", name, want, got)
        }

        return 0
    }
}
```

If `want` and/or `got` are `string` or `int` or any Go types, the current implementation will return `nil`.  Then the following assertion would fail:

``` lua
notequals("Should not be equal", "hello", 1)
-- dont want `<nil>` but got it (<nil>)
```

This is because `"hello"` and `1` are going to be returned as type `string` and `int` from the VM, which will mask them as `nil` in the current `ToValue` implementation.

``` go
want := lua.ToValue(l, 2)
got := lua.ToValue(l, 3)
// want and got are both `nil`
if reflect.DeepEqual(want, got) {
    t.Errorf("%s: dont want `%#v` but got it (%#v)", name, want, got)
}
```
## Solution

Add a case to the switch in `ToValue`:

``` go
func ToValue(l *State, index int) interface{} {
    v := l.indexToValue(index)
    switch v := v.(type) {
    case string, uint, int, float64, bool:
    case *table:
    // more cases
    default:
        return nil
    }
    return v
}
```
