### PR TITLE
Improve error message when requiring missing module.

### DIFF
--- a/load.go
+++ b/load.go
@@ -2,9 +2,14 @@ package lua
 
 func findLoader(l *State, name string) {
 	// TODO accumulate errors?
-	if Field(l, UpValueIndex(1), "searchers"); !IsTable(l, 3) {
+	Field(l, UpValueIndex(1), "searchers")
+	if IsNil(l, 3) {
+		Errorf(l, "module '%s' not found", name)
+	}
+	if !IsTable(l, 3) {
 		Errorf(l, "'package.searchers' must be a table")
 	}
+
 	for i := 1; ; i++ {
 		if RawGetInt(l, 3, i); IsNil(l, -1) {
 			Pop(l, 1)


### PR DESCRIPTION
I was having fun with goluago when I tried to do something like

``` lua
local strings = require('goluago/string')
```

The message I got was

```
'package.searchers' must be a table
```

which I found pretty confusing.

I added a `nil` check with a more user friendly error message for the next person who gets this error. I hope it makes sense.

r: @fbogsany 
