### PR TITLE
Throw RuntimeError as a structured error

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -128,7 +128,7 @@ func (l *State) errorMessage() {
 		l.top++
 		l.call(l.top-2, 1, false)
 	}
-	l.throw(fmt.Errorf("%v: %s", RuntimeError, CheckString(l, -1)))
+	l.throw(RuntimeError(CheckString(l, -1)))
 }
 
 func SetHooker(l *State, f Hook, mask byte, count int) {

--- a/lua.go
+++ b/lua.go
@@ -21,12 +21,15 @@ const (
 )
 
 var (
-	RuntimeError = errors.New("runtime error")
-	SyntaxError  = errors.New("syntax error")
-	MemoryError  = errors.New("memory error")
-	ErrorError   = errors.New("error within the error handler")
-	FileError    = errors.New("file error")
+	SyntaxError = errors.New("syntax error")
+	MemoryError = errors.New("memory error")
+	ErrorError  = errors.New("error within the error handler")
+	FileError   = errors.New("file error")
 )
+
+type RuntimeError string
+
+func (r RuntimeError) Error() string { return "runtime error: " + string(r) }
 
 type Type int
 


### PR DESCRIPTION
This makes RuntimeError a structured error type, instead of embedding it in a string.
