### PR TITLE
Push nil if uservalue is nil

### DIFF
--- a/lua.go
+++ b/lua.go
@@ -967,7 +967,11 @@ func MetaTable(l *State, index int) bool {
 // http://www.lua.org/manual/5.2/manual.html#lua_getuservalue
 func UserValue(l *State, index int) {
 	d := l.indexToValue(index).(*userData)
-	l.apiPush(d.env)
+	if d.env == nil {
+		l.apiPush(nil)
+	} else {
+		l.apiPush(d.env)
+	}
 }
 
 // SetGlobal pops a value from the stack and sets it as the new value of


### PR DESCRIPTION
If a userdata has a `nil` uservalue, `UserValue` will push it as `{*table, nil}` instead of `{nil, nil}`, so `IsNil` will incorrectly return `false` and attempts to index into the table will fail.

This instead pushes an explicit `nil` (i.e. `{nil, nil}`) if the uservalue is `nil`.
