### PR TITLE
add an environment to lua.State

### DIFF
--- a/base.go
+++ b/base.go
@@ -2,7 +2,6 @@ package lua
 
 import (
 	"io"
-	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -215,13 +214,21 @@ var baseLibrary = []RegistryFunction{
 				panic("unreachable")
 			}
 			if i > 1 {
-				os.Stdout.WriteString("\t")
+				if _, err := l.Env.Stdout.Write([]byte("\t")); err != nil {
+					Errorf(l, err.Error())
+					panic("unreachable")
+				}
 			}
-			os.Stdout.WriteString(s)
+			if _, err := l.Env.Stdout.Write([]byte(s)); err != nil {
+				Errorf(l, err.Error())
+				panic("unreachable")
+			}
 			l.Pop(1) // pop result
 		}
-		os.Stdout.WriteString("\n")
-		os.Stdout.Sync()
+		if _, err := l.Env.Stdout.Write([]byte("\n")); err != nil {
+			Errorf(l, err.Error())
+			panic("unreachable")
+		}
 		return 0
 	}},
 	{"rawequal", func(l *State) int {


### PR DESCRIPTION
 I'd like to be able to decouple the `lua.State` from my Go process. For instance, be able to have multiple `lua.State` that `print("hello world")` and be able to capture their output individually.

For this, I thought of introducing an `Environment` struct in the `lua.State` which is used by libraries that would otherwise use the Go `os` package. By default, the `Environment` is set to us `os.Stdout/err/in` though they are now configurable.

For instance, I want to be able to do (derivative work):

```go
func TestLuaEngine(t *testing.T) {
	buf := bytes.NewBuffer(nil)

	script := `print("hello world")`
	eng, err := engine.Lua(script)
	if err != nil {
		t.Fatal(err)
	}
	eng.SetStdout(buf)
	err := eng.Execute(context.Background())
	if err != nil {
		t.Fatal(err)
	}
	if want, got := "hello world", buf.String(); want != got {
		t.Fatalf("want output %q, got %q", want, got)
	}
}
```

Thoughts?

@fbogsany