### PR TITLE
Handle runtime panic where comparison operand is nil

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -102,13 +102,19 @@ func (l *State) equalObjects(t1, t2 value) bool {
 	case *userData:
 		if t1 == t2 {
 			return true
+		} else if t2, ok := t2.(*userData); ok && t2 != nil {
+			tm = l.equalTagMethod(t1.metaTable, t2.metaTable, tmEq)
+		} else if !ok || t2 == nil {
+			return false
 		}
-		tm = l.equalTagMethod(t1.metaTable, t2.(*userData).metaTable, tmEq)
 	case *table:
 		if t1 == t2 {
 			return true
+		} else if t2, ok := t2.(*table); ok && t2 != nil {
+			tm = l.equalTagMethod(t1.metaTable, t2.metaTable, tmEq)
+		} else if !ok || t2 == nil {
+			return false
 		}
-		tm = l.equalTagMethod(t1.metaTable, t2.(*table).metaTable, tmEq)
 	default:
 		return t1 == t2
 	}

--- a/vm.go
+++ b/vm.go
@@ -102,18 +102,14 @@ func (l *State) equalObjects(t1, t2 value) bool {
 	case *userData:
 		if t1 == t2 {
 			return true
-		} else if t2, ok := t2.(*userData); ok && t2 != nil {
+		} else if t2, ok := t2.(*userData); ok {
 			tm = l.equalTagMethod(t1.metaTable, t2.metaTable, tmEq)
-		} else if !ok || t2 == nil {
-			return false
 		}
 	case *table:
 		if t1 == t2 {
 			return true
-		} else if t2, ok := t2.(*table); ok && t2 != nil {
+		} else if t2, ok := t2.(*table); ok {
 			tm = l.equalTagMethod(t1.metaTable, t2.metaTable, tmEq)
-		} else if !ok || t2 == nil {
-			return false
 		}
 	default:
 		return t1 == t2

--- a/vm_test.go
+++ b/vm_test.go
@@ -176,6 +176,58 @@ func TestCanRemoveNilObjectFromStack(t *testing.T) {
 	l.Remove(-1)
 }
 
+func TestTableUserdataEquality(t *testing.T) {
+	const s = `return function(x)
+		local b = x == {}
+		assert(type(b) == "boolean")
+		assert(b == false)
+		-- reverse
+		b = {} == x
+		assert(type(b) == "boolean")
+		assert(b == false)
+	end`
+
+	l := NewState()
+	OpenLibraries(l)
+	LoadString(l, s)
+	if err := l.ProtectedCall(0, 1, 0); err != nil {
+		t.Error(err.Error())
+	}
+
+	l.PushUserData(5)
+	if err := l.ProtectedCall(1, 0, 0); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestUserDataEqualityNil(t *testing.T) {
+	const s = `return function(x)
+		local b = x == nil
+		assert(type(b) == "boolean")
+		assert(b == false)
+	end`
+
+	l := NewState()
+	OpenLibraries(l)
+	LoadString(l, s)
+	if err := l.ProtectedCall(0, 1, 0); err != nil {
+		t.Error(err.Error())
+	}
+
+	l.PushUserData(5)
+	if err := l.ProtectedCall(1, 0, 0); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestTableEqualityNil(t *testing.T) {
+	const s = `local b = {} == nil
+	assert(type(b) == "boolean")
+	assert(b == false)`
+
+	testString(t, s)
+}
+
 func TestTableNext(t *testing.T) {
 	l := NewState()
 	OpenLibraries(l)


### PR DESCRIPTION
All table/UD comparisons were assuming the other operand wasn't nil. This doesn't mesh with Lua, since it results in a panic where the result should be false. Related to issue #45 and pull request #57, but addresses the issue for userdata as well.

The issue's pretty simple: if one side of the comparison is a table or userdata and the other side is nil, the other side is assumed to be a userdata or table and a type assertion is made. If the assertion fails, the program has a runtime panic and dies.

I don't know if this issue exists for metamethods on other types as well.