### PR TITLE
Fix var order on objectName return

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -76,7 +76,7 @@ func (l *State) typeError(v value, operation string) {
 			return false
 		}
 		if !isUpValue() && isInStack() {
-			kind, name = c.prototype.objectName(frameIndex, ci.savedPC)
+			name, kind = c.prototype.objectName(frameIndex, ci.savedPC)
 		}
 		if kind != "" {
 			l.runtimeError(fmt.Sprintf("attempt to %s %s '%s' (a %s value)", operation, kind, name, typeName))


### PR DESCRIPTION
Was producing incorrect / confusing error messages.