### PR TITLE
Pass correct reader (bufio.Reader) to undump

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -682,7 +682,7 @@ func protectedParser(l *State, r io.Reader, name, chunkMode string) error {
 		} else if c == Signature[0] {
 			l.checkMode(chunkMode, "binary")
 			b.UnreadByte()
-			closure, err = l.undump(r, name) // TODO handle err
+			closure, err = l.undump(b, name) // TODO handle err
 		} else {
 			l.checkMode(chunkMode, "text")
 			b.UnreadByte()


### PR DESCRIPTION
Fixes broken binary loading for e.g., loading binaries from a string
reader. Previously, the walkback on the byte read would be ignored,
resulting in incorrect data being read and a panic later from accessing
the resulting closure (since the error is effectively ignored in this
function).