### PR TITLE
Fix split call info code slices on opTailCall

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -758,6 +758,7 @@ func init() {
 				oci.setTop(ofn + (e.l.top - nfn)) // correct top
 				oci.frame = e.l.stack[base:oci.top]
 				oci.savedPC = nci.savedPC
+				oci.code = nci.code               // correct code (savedPC indexes nci->code)
 				oci.setCallStatus(callStatusTail) // function was tail called
 				e.l.top, e.l.callInfo, e.callInfo = oci.top, oci, oci
 				// TODO e.l.assert(e.l.top == oci.base()+e.l.stack[ofn].(*luaClosure).prototype.maxStackSize)
@@ -1226,6 +1227,7 @@ func (l *State) executeSwitch() {
 				oci.setTop(ofn + (l.top - nfn))  // correct top
 				oci.frame = l.stack[base:oci.top]
 				oci.savedPC = nci.savedPC
+				oci.code = nci.code               // correct code (savedPC indexes nci->code)
 				oci.setCallStatus(callStatusTail) // function was tail called
 				l.top, l.callInfo, ci = oci.top, oci, oci
 				// TODO l.assert(l.top == oci.base()+l.stack[ofn].(*luaClosure).prototype.maxStackSize)


### PR DESCRIPTION
These changes attempt to address the `opTailCall` issue (#46) by adding
enough tests to figure out which sorts of tail calls fail and, following
that, fix the issue itself.

The tests, as basic as they are, show that `opTailCall` only really
fails if the function being called is different from the current
function (i.e., `oci` and `nci` in `opTailCall` don't refer to the same
code path).

After scanning through the C code and the changes needed to make go-lua
work, it seems there was a small omission in `opTailCall` that forgot to
account that the saved PC of call-info in C Lua is a pointer, and that
it uses pointer arithmetic to get each instruction. The go-lua
implementation changes this by making the saved PC an integer index into
a slice. So, copying the PC from `nci` to `oci` isn't enough when making
a tailcall: go-lua also needs to copy the code slice from `nci` to
`oci`.

Fixes issue #46.