### PR TITLE
Fix PushFString %p format token.

### DIFF
--- a/lua.go
+++ b/lua.go
@@ -911,6 +911,7 @@ func (l *State) PushFString(format string, args ...interface{}) string {
 			i++
 		case 'p':
 			l.push(fmt.Sprintf("%p", args[i]))
+			i++
 		case '%':
 			l.push("%")
 		default:

--- a/lua_test.go
+++ b/lua_test.go
@@ -1,8 +1,20 @@
 package lua
 
-import "testing"
+import (
+	"regexp"
+	"testing"
+)
 
+// https://github.com/Shopify/go-lua/pull/63
 func TestPushFStringPointer(t *testing.T) {
 	l := NewState()
 	l.PushFString("%p %s", l, "test")
+
+	actual := CheckString(l, -1)
+	ok, err := regexp.MatchString("0x[0-9a-f]+ test", actual)
+	if !ok {
+		t.Error("regex did not match")
+	} else if err != nil {
+		t.Errorf("regex error: %s", err.Error())
+	}
 }

--- a/lua_test.go
+++ b/lua_test.go
@@ -1,20 +1,17 @@
 package lua
 
 import (
-	"regexp"
+	"fmt"
 	"testing"
 )
 
-// https://github.com/Shopify/go-lua/pull/63
 func TestPushFStringPointer(t *testing.T) {
 	l := NewState()
 	l.PushFString("%p %s", l, "test")
 
+	expected := fmt.Sprintf("%p %s", l, "test")
 	actual := CheckString(l, -1)
-	ok, err := regexp.MatchString("0x[0-9a-f]+ test", actual)
-	if !ok {
-		t.Error("regex did not match")
-	} else if err != nil {
-		t.Errorf("regex error: %s", err.Error())
+	if expected != actual {
+		t.Errorf("PushFString, expected \"%s\" but found \"%s\"", expected, actual)
 	}
 }

--- a/lua_test.go
+++ b/lua_test.go
@@ -1,0 +1,8 @@
+package lua
+
+import "testing"
+
+func TestPushFStringPointer(t *testing.T) {
+	l := NewState()
+	l.PushFString("%p %s", l, "test")
+}


### PR DESCRIPTION
Fixes a nasty bug where using a %p in a format string does not advance
the argument index, which causes the next format token to look at the
same argument again and all subsequent tokens will be off-by-one.