### PR TITLE
Return proper errors in LoadFile and LoadString

### DIFF
--- a/auxiliary.go
+++ b/auxiliary.go
@@ -508,9 +508,7 @@ func LoadFile(l *State, fileName, mode string) error {
 		_ = f.Close()
 	}
 	switch err {
-	case nil: // do nothing
-	case SyntaxError: // do nothing
-	case MemoryError: // do nothing
+	case nil, SyntaxError, MemoryError: // do nothing
 	default:
 		l.SetTop(fileNameIndex)
 		return fileError("read")

--- a/auxiliary.go
+++ b/auxiliary.go
@@ -507,7 +507,11 @@ func LoadFile(l *State, fileName, mode string) error {
 	if f != os.Stdin {
 		_ = f.Close()
 	}
-	if err != nil {
+	switch err {
+	case nil: // do nothing
+	case SyntaxError: // do nothing
+	case MemoryError: // do nothing
+	default:
 		l.SetTop(fileNameIndex)
 		return fileError("read")
 	}

--- a/auxiliary_test.go
+++ b/auxiliary_test.go
@@ -1,0 +1,39 @@
+package lua
+
+import "testing"
+
+func TestLoadFileSyntaxError(t *testing.T) {
+	l := NewState()
+	err := LoadFile(l, "fixtures/syntax_error.lua", "")
+	if err != SyntaxError {
+		t.Error("didn't return SyntaxError on file with syntax error")
+	}
+	if l.Top() != 1 {
+		t.Error("didn't push anything to the stack")
+	}
+	if l.IsString(-1) != true {
+		t.Error("didn't push a string to the stack")
+	}
+	estr, _ := l.ToString(-1)
+	if estr != "fixtures/syntax_error.lua:4: syntax error near <eof>" {
+		t.Error("didn't push the correct error string")
+	}
+}
+
+func TestLoadStringSyntaxError(t *testing.T) {
+	l := NewState()
+	err := LoadString(l, "this_is_a_syntax_error")
+	if err != SyntaxError {
+		t.Error("didn't return SyntaxError on string with syntax error")
+	}
+	if l.Top() != 1 {
+		t.Error("didn't push anything to the stack")
+	}
+	if l.IsString(-1) != true {
+		t.Error("didn't push a string to the stack")
+	}
+	estr, _ := l.ToString(-1)
+	if estr != "[string \"this_is_a_syntax_error\"]:1: syntax error near <eof>" {
+		t.Error("didn't push the correct error string")
+	}
+}

--- a/fixtures/syntax_error.lua
+++ b/fixtures/syntax_error.lua
@@ -1,0 +1,3 @@
+-- A file that should generate a syntax error
+
+this_is_a_syntax_error

--- a/scanner.go
+++ b/scanner.go
@@ -99,10 +99,11 @@ func (s *scanner) tokenToString(t rune) string {
 }
 
 func (s *scanner) scanError(message string, token rune) {
+	buff := chunkID(s.source)
 	if token != 0 {
-		message = fmt.Sprintf("%s:%d: %s near %s", s.source, s.lineNumber, message, s.tokenToString(token))
+		message = fmt.Sprintf("%s:%d: %s near %s", buff, s.lineNumber, message, s.tokenToString(token))
 	} else {
-		message = fmt.Sprintf("%s:%d: %s", s.source, s.lineNumber, message)
+		message = fmt.Sprintf("%s:%d: %s", buff, s.lineNumber, message)
 	}
 	s.l.push(message)
 	s.l.throw(SyntaxError)


### PR DESCRIPTION
- Error messages did not properly chunkID the source filename, leading to @'s next to filenames and such.
- LoadFile improperly raised a generic file read error, even if the actual error was a Lua error such as a SyntaxError.