### PR TITLE
Fix ToBoolean returning true for none values

### DIFF
--- a/lua_test.go
+++ b/lua_test.go
@@ -15,3 +15,17 @@ func TestPushFStringPointer(t *testing.T) {
 		t.Errorf("PushFString, expected \"%s\" but found \"%s\"", expected, actual)
 	}
 }
+
+func TestToBooleanOutOfRange(t *testing.T) {
+	l := NewState()
+	l.SetTop(0)
+	l.PushBoolean(false)
+	l.PushBoolean(true)
+
+	for i, want := range []bool{false, true, false, false} {
+		idx := 1 + i
+		if got := l.ToBoolean(idx); got != want {
+			t.Errorf("l.ToBoolean(%d) = %t; want %t", idx, got, want)
+		}
+	}
+}

--- a/string.go
+++ b/string.go
@@ -25,7 +25,8 @@ func findHelper(l *State, isFind bool) int {
 		l.PushNil()
 		return 1
 	}
-	if isFind && (l.ToBoolean(4) || !strings.ContainsAny(p, "^$*+?.([%-")) {
+	isPlain := l.TypeOf(4) == TypeNone || l.ToBoolean(4)
+	if isFind && (isPlain || !strings.ContainsAny(p, "^$*+?.([%-")) {
 		if start := strings.Index(s[init-1:], p); start >= 0 {
 			l.PushInteger(start + init)
 			l.PushInteger(start + init + len(p) - 1)

--- a/types.go
+++ b/types.go
@@ -62,7 +62,7 @@ func stack(s []value) string {
 }
 
 func isFalse(s value) bool {
-	if s == nil {
+	if s == nil || s == none {
 		return true
 	}
 	b, isBool := s.(bool)


### PR DESCRIPTION
This adds a test to check ToBoolean results for out of range stack
indices and adds a check in isFalse to return true for values that are
none (i.e., not in range). Commit 896832c makes the test pass, but
breaks string.find because it relies on ToBoolean's incorrect behavior.

Because ToBoolean being wrong factored into string.find working
correctly, the findHelper function has also been updated to check if
string.find's plain argument is none (i.e., whether it's been passed).
This is fixed in deba37c and allows lua-tests modules to pass tests.

Closes #68.