### PR TITLE
Pattern Matching

### DIFF
--- a/auxiliary.go
+++ b/auxiliary.go
@@ -507,7 +507,11 @@ func LoadFile(l *State, fileName, mode string) error {
 	if f != os.Stdin {
 		_ = f.Close()
 	}
-	if err != nil {
+	switch err {
+	case nil: // do nothing
+	case SyntaxError: // do nothing
+	case MemoryError: // do nothing
+	default:
 		l.SetTop(fileNameIndex)
 		return fileError("read")
 	}

--- a/auxiliary_test.go
+++ b/auxiliary_test.go
@@ -1,0 +1,39 @@
+package lua
+
+import "testing"
+
+func TestLoadFileSyntaxError(t *testing.T) {
+	l := NewState()
+	err := LoadFile(l, "fixtures/syntax_error.lua", "")
+	if err != SyntaxError {
+		t.Error("didn't return SyntaxError on file with syntax error")
+	}
+	if l.Top() != 1 {
+		t.Error("didn't push anything to the stack")
+	}
+	if l.IsString(-1) != true {
+		t.Error("didn't push a string to the stack")
+	}
+	estr, _ := l.ToString(-1)
+	if estr != "fixtures/syntax_error.lua:4: syntax error near <eof>" {
+		t.Error("didn't push the correct error string")
+	}
+}
+
+func TestLoadStringSyntaxError(t *testing.T) {
+	l := NewState()
+	err := LoadString(l, "this_is_a_syntax_error")
+	if err != SyntaxError {
+		t.Error("didn't return SyntaxError on string with syntax error")
+	}
+	if l.Top() != 1 {
+		t.Error("didn't push anything to the stack")
+	}
+	if l.IsString(-1) != true {
+		t.Error("didn't push a string to the stack")
+	}
+	estr, _ := l.ToString(-1)
+	if estr != "[string \"this_is_a_syntax_error\"]:1: syntax error near <eof>" {
+		t.Error("didn't push the correct error string")
+	}
+}

--- a/fixtures/syntax_error.lua
+++ b/fixtures/syntax_error.lua
@@ -1,0 +1,3 @@
+-- A file that should generate a syntax error
+
+this_is_a_syntax_error

--- a/pattern.go
+++ b/pattern.go
@@ -68,7 +68,7 @@ func classend(ms *matchState, ppos int) int {
 			}
 			ppos++
 			if (*ms.p)[ppos] == lEsc && ppos < len(*ms.p) {
-				ppos++ // skip escapes (e.g. `%]')
+				ppos = ppos + 2 // skip escapes (e.g. `%]')
 			}
 			if (*ms.p)[ppos] == ']' {
 				break
@@ -95,7 +95,7 @@ func matchClass(c byte, cl byte) bool {
 	case 'l':
 		res = unicode.IsLower(rc)
 	case 'p':
-		res = unicode.IsPunct(rc)
+		res = unicode.In(rc, unicode.Mark, unicode.Punct, unicode.Symbol)
 	case 's':
 		res = unicode.IsSpace(rc)
 	case 'u':
@@ -547,7 +547,7 @@ func strGsub(l *State) int {
 	tr := l.TypeOf(3)
 	maxS := OptInteger(l, 4, len(src)+1)
 
-	anchor := p[0] == '^'
+	anchor := len(p) > 0 && p[0] == '^'
 	n := 0
 
 	ArgumentCheck(l, tr == TypeNumber || tr == TypeString || tr == TypeFunction || tr == TypeTable, 3, "string/function/table expected")

--- a/pattern.go
+++ b/pattern.go
@@ -456,8 +456,7 @@ func strFindAux(l *State, find bool) int {
 		return 1
 	}
 	// explicit request or no special characters?
-	// FIXME: ToBoolean returns true for invalid index
-	if find && (l.Top() >= 4 && l.ToBoolean(4)) || nospecials(p) {
+	if find && l.ToBoolean(4) || nospecials(p) {
 		// do a plain search
 		s2 := strings.Index(s[init-1:], p)
 		if s2 != -1 {

--- a/pattern.go
+++ b/pattern.go
@@ -53,9 +53,30 @@ func classend(ms *matchState, ppos int) int {
 
 func matchClass(c byte, cl byte) bool {
 	var res bool
-	var rcl rune = rune(cl)
+	var rc, rcl rune = rune(c), rune(cl)
 	switch unicode.ToLower(rcl) {
-	// TODO: Implement other cases...
+	case 'a':
+		res = unicode.IsLetter(rc)
+	case 'c':
+		res = unicode.IsControl(rc)
+	case 'd':
+		res = unicode.IsDigit(rc)
+	case 'g':
+		res = unicode.IsGraphic(rc) && !unicode.IsSpace(rc)
+	case 'l':
+		res = unicode.IsLower(rc)
+	case 'p':
+		res = unicode.IsPunct(rc)
+	case 's':
+		res = unicode.IsSpace(rc)
+	case 'u':
+		res = unicode.IsUpper(rc)
+	case 'w':
+		res = unicode.In(rc, unicode.Letter, unicode.Number)
+	case 'x':
+		res = unicode.In(rc, unicode.Hex_Digit)
+	case 'z':
+		res = (c == 0)
 	default:
 		return cl == c
 	}

--- a/pattern.go
+++ b/pattern.go
@@ -90,45 +90,66 @@ func match(ms *matchState, spos int, ppos int) (int, bool) {
 	}
 	ms.matchDepth--
 	ok := true
+
+	// The default case - return true to goto init
+	defaultCase := func() bool {
+		eppos := classend(ms, ppos) // points to optional suffix
+		// does not match at least once?
+		if !singlematch(ms, spos, ppos, eppos) {
+			var ep byte = 0
+			if eppos != len(*ms.p) {
+				ep = (*ms.p)[eppos]
+			}
+			if ep == '*' || ep == '?' || ep == '-' { // accept empty?
+				ppos = eppos + 1
+				return true // return match(ms, spos, eppos + 1);
+			} else { // '+' or no suffix
+				ok = false // fail
+			}
+		} else { // matched once
+			var ep byte = 0
+			if eppos != len(*ms.p) {
+				ep = (*ms.p)[eppos]
+			}
+			switch ep {
+			case '?': // optional
+				// TODO
+			case '+': // 1 or more repetitions
+				// TODO
+				fallthrough
+			case '*': // 0 or more repetitions
+				// TODO
+			case '-': // 0 or more repetitions (minimum)
+				// TODO
+			default: // no suffix
+				spos++
+				ppos = eppos
+				return true
+			}
+		}
+		return false
+	}
+
 init: // using goto's to optimize tail recursion
 	if ppos != len(*ms.p) { // end of pattern?
 		switch (*ms.p)[ppos] {
-		default: // pattern class plus optional suffix
-			{
-				eppos := classend(ms, ppos) // points to optional suffix
-				// does not match at least once?
-				if !singlematch(ms, spos, ppos, eppos) {
-					var ep byte = 0
-					if eppos != len(*ms.p) {
-						ep = (*ms.p)[eppos]
-					}
-					if ep == '*' || ep == '?' || ep == '-' { // accept empty?
-						ppos = eppos + 1
-						goto init // return match(ms, spos, eppos + 1);
-					} else { // '+' or no suffix
-						ok = false // fail
-					}
-				} else { // matched once
-					var ep byte = 0
-					if eppos != len(*ms.p) {
-						ep = (*ms.p)[eppos]
-					}
-					switch ep {
-					case '?': // optional
-						// TODO
-					case '+': // 1 or more repetitions
-						// TODO
-						fallthrough
-					case '*': // 0 or more repetitions
-						// TODO
-					case '-': // 0 or more repetitions (minimum)
-						// TODO
-					default: // no suffix
-						spos++
-						ppos = eppos
-						goto init
-					}
+		case lEsc:
+			pnext := (*ms.p)[ppos+1]
+			switch {
+			case pnext == 'b': // balanced string?
+				// TODO
+			case pnext == 'f': // frontier?
+				// TODO
+			case pnext >= '0' && pnext <= '9': /* capture results (%0-%9)? */
+				// TODO
+			default:
+				if defaultCase() {
+					goto init
 				}
+			}
+		default: // pattern class plus optional suffix
+			if defaultCase() {
+				goto init
 			}
 		}
 	}

--- a/scanner.go
+++ b/scanner.go
@@ -99,10 +99,11 @@ func (s *scanner) tokenToString(t rune) string {
 }
 
 func (s *scanner) scanError(message string, token rune) {
+	buff := chunkID(s.source)
 	if token != 0 {
-		message = fmt.Sprintf("%s:%d: %s near %s", s.source, s.lineNumber, message, s.tokenToString(token))
+		message = fmt.Sprintf("%s:%d: %s near %s", buff, s.lineNumber, message, s.tokenToString(token))
 	} else {
-		message = fmt.Sprintf("%s:%d: %s", s.source, s.lineNumber, message)
+		message = fmt.Sprintf("%s:%d: %s", buff, s.lineNumber, message)
 	}
 	s.l.push(message)
 	s.l.throw(SyntaxError)

--- a/string.go
+++ b/string.go
@@ -178,7 +178,7 @@ var stringLibrary = []RegistryFunction{
 		l.PushString(formatHelper(l, CheckString(l, 1), l.Top()))
 		return 1
 	}},
-	// {"gmatch", ...},
+	{"gmatch", gmatch},
 	// {"gsub", ...},
 	{"len", func(l *State) int { l.PushInteger(len(CheckString(l, 1))); return 1 }},
 	{"lower", func(l *State) int { l.PushString(strings.ToLower(CheckString(l, 1))); return 1 }},

--- a/string.go
+++ b/string.go
@@ -16,28 +16,6 @@ func relativePosition(pos, length int) int {
 	return length + pos + 1
 }
 
-func findHelper(l *State, isFind bool) int {
-	s, p := CheckString(l, 1), CheckString(l, 2)
-	init := relativePosition(OptInteger(l, 3, 1), len(s))
-	if init < 1 {
-		init = 1
-	} else if init > len(s)+1 {
-		l.PushNil()
-		return 1
-	}
-	if isFind && (l.ToBoolean(4) || !strings.ContainsAny(p, "^$*+?.([%-")) {
-		if start := strings.Index(s[init-1:], p); start >= 0 {
-			l.PushInteger(start + init)
-			l.PushInteger(start + init + len(p) - 1)
-			return 2
-		}
-	} else {
-		l.assert(false) // TODO implement pattern matching
-	}
-	l.PushNil()
-	return 1
-}
-
 func scanFormat(l *State, fs string) string {
 	i := 0
 	skipDigit := func() {
@@ -173,16 +151,16 @@ var stringLibrary = []RegistryFunction{
 		return 1
 	}},
 	// {"dump", ...},
-	{"find", func(l *State) int { return findHelper(l, true) }},
+	{"find", strFind},
 	{"format", func(l *State) int {
 		l.PushString(formatHelper(l, CheckString(l, 1), l.Top()))
 		return 1
 	}},
 	{"gmatch", gmatch},
-	// {"gsub", ...},
+	{"gsub", strGsub},
 	{"len", func(l *State) int { l.PushInteger(len(CheckString(l, 1))); return 1 }},
 	{"lower", func(l *State) int { l.PushString(strings.ToLower(CheckString(l, 1))); return 1 }},
-	// {"match", ...},
+	{"match", strMatch},
 	{"rep", func(l *State) int {
 		s, n, sep := CheckString(l, 1), CheckInteger(l, 2), OptString(l, 3, "")
 		if n <= 0 {

--- a/vm_test.go
+++ b/vm_test.go
@@ -72,7 +72,7 @@ func TestLua(t *testing.T) {
 		// {name: "main"},
 		{name: "math"},
 		// {name: "nextvar"},
-		// {name: "pm"},
+		{name: "pm"},
 		{name: "sort", nonPort: true}, // sort.lua depends on os.clock(), which is not yet implemented on Windows.
 		{name: "strings"},
 		// {name: "vararg"},
@@ -108,7 +108,12 @@ func TestLua(t *testing.T) {
 		}
 		// l.Call(0, 0)
 		if err := l.ProtectedCall(0, 0, traceback); err != nil {
-			t.Errorf("'%s' failed: %s", v.name, err.Error())
+			str, ok := l.ToString(-1)
+			if ok {
+				t.Errorf("'%s' failed: %s", v.name, str)
+			} else {
+				t.Errorf("'%s' failed (no Lua message): %s", v.name, err.Error())
+			}
 		}
 	}
 }


### PR DESCRIPTION
So yeah, pattern matching.  Hooray.

- All of the "pm.lua" tests pass.
- This implementation sticks pretty close to the original C implementation - I figured it was better to be safe than sorry.  Comments from the original implementation have been preserved to better orient code spelunkers.
- Passing pointers to string positions isn't really a thing in Go, and I wasn't sure I could replicate some of the pointer arithmetic of the original code using slices, so instead I pass around string positions as integers.
- Several instances of relying on returning a NULL pointer as a failure state have been converted into Go-style multiple-return with an *ok* boolean.
- The original implementation uses `goto` in the main match function in order to keep the stack under control, and this has been preserved with slight alterations in order to accommodate Go's stricter rules on where you can and can't jump to.  In my research, it appears that Go stacks are (nearly) infinite, but I'm not sure that means converting the jumps to recursive function calls is necessarily a good idea..

Also, my apologies, but I actually started this branch midway through #67, so I would merge that before looking at this.  I also added a little helpful bit to the Lua test harness that returns the error string off the stack if one exists when running the test suite - if you would rather that be in a separate pull request, it can be backed out.