### PR TITLE
add luac version check to dev

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -6,6 +6,16 @@ up:
       name: Initializing submodules
       met?: test -f lua-tests/.git
       meet: git submodule update --init
+  - custom:
+      name: Lua version check
+      met?: |
+        if [ ! $(luac -v | awk ' { print $2 }') == "5.2.4" ]; then
+          echo "Luac version 5.2.4 is required."
+          echo "Luac is installed with Lua."
+          echo "brew install lua"
+          exit 1
+        fi
+      meet: 'true'
 
 commands:
   test:


### PR DESCRIPTION
go-lua requires a luac version of 5.2.x. 
Other version of luac will cause problems like having all the tests fail with a panic. 

To avoid other people the trouble of debugging why this is happening, Ive aded a check to dev to ensure the required version of luac is met. 
