### PR TITLE
Naming things, cache invalidation and ...

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -14,7 +14,7 @@ func (l *State) prototype(ci *callInfo) *prototype {
 	return l.stack[ci.function].(*luaClosure).prototype
 }
 func (l *State) currentLine(ci *callInfo) int {
-	return int(l.prototype(ci).lineInfo[ci.savedPC])
+	return int(l.prototype(ci).lineInfo[ci.savedPC - 1])
 }
 
 func chunkID(source string) string {

--- a/vm_test.go
+++ b/vm_test.go
@@ -402,8 +402,8 @@ func TestLocIsCorrectOnRegisteredFuncCall(t *testing.T) {
 		return 0
 	})
 	if err := l.Load(strings.NewReader(`
-			local thing = barf() 	-- line 2; is the source of the error
-			print(thing) 			-- line 3; this won't execute, and must NOT be the loc of the error!
+			local thing = barf()  -- line 2; is the source of the error
+			print(thing)          -- line 3; this won't execute, and must NOT be the loc of the error!
 			`), "test", ""); err != nil {
 		t.Errorf("Unexpected error! Got %v", err)
 	}
@@ -422,9 +422,9 @@ func TestLocIsCorrectOnFuncCall(t *testing.T) {
 	if err := l.Load(strings.NewReader(`
 			function barf()
 				a = 3 + 2
-				isNotDefined("Boom!", a)	-- line 4; is the source of the error
+				isNotDefined("Boom!", a)  -- line 4; is the source of the error
 			end
-			barf() 				  			-- line 6
+			barf()                        -- line 6
 			`), "test", ""); err != nil {
 		t.Errorf("Unexpected error! Got %v", err)
 	}
@@ -433,6 +433,24 @@ func TestLocIsCorrectOnFuncCall(t *testing.T) {
 		t.Errorf("Expected error! Got none... :(")
 	} else {
 		if err.Error() != "runtime error: [string \"test\"]:4: attempt to call a nil value" {
+			t.Errorf("Wrong error reported: %v", err)
+		}
+	}
+}
+
+func TestLocIsCorrectOnError(t *testing.T) {
+	l := NewState()
+	if err := l.Load(strings.NewReader(`
+			a = 3 - 3
+			b = 3 / q  -- line 3; errs!
+			`), "test", ""); err != nil {
+		t.Errorf("Unexpected error! Got %v", err)
+	}
+	err := l.ProtectedCall(0, 0, 0)
+	if err == nil {
+		t.Errorf("Expected error! Got none... :(")
+	} else {
+		if err.Error() != "runtime error: [string \"test\"]:3: attempt to perform arithmetic on a nil value" {
 			t.Errorf("Wrong error reported: %v", err)
 		}
 	}

--- a/vm_test.go
+++ b/vm_test.go
@@ -394,3 +394,46 @@ func TestConcurrentNext(t *testing.T) {
 	assert(got == '123', 'got ' .. got .. '; want 123')
 	`)
 }
+
+func TestLocIsCorrectOnRegisteredFuncCall(t *testing.T) {
+	l := NewState()
+	l.Register("barf", func(l *State) int {
+		Errorf(l, "Boom!")
+		return 0
+	})
+	if err := l.Load(strings.NewReader(`
+			local thing = barf() 	-- line 2; is the source of the error
+			print(thing) 			-- line 3; this won't execute, and must NOT be the loc of the error!
+			`), "test", ""); err != nil {
+		t.Errorf("Unexpected error! Got %v", err)
+	}
+	err := l.ProtectedCall(0, 0, 0)
+	if err == nil {
+		t.Errorf("Expected error! Got none... :(")
+	} else {
+		if err.Error() != "runtime error: [string \"test\"]:2: Boom!" {
+			t.Errorf("Wrong error reported: %v", err)
+		}
+	}
+}
+
+func TestLocIsCorrectOnFuncCall(t *testing.T) {
+	l := NewState()
+	if err := l.Load(strings.NewReader(`
+			function barf()
+				a = 3 + 2
+				isNotDefined("Boom!", a)	-- line 4; is the source of the error
+			end
+			barf() 				  			-- line 6
+			`), "test", ""); err != nil {
+		t.Errorf("Unexpected error! Got %v", err)
+	}
+	err := l.ProtectedCall(0, 0, 0)
+	if err == nil {
+		t.Errorf("Expected error! Got none... :(")
+	} else {
+		if err.Error() != "runtime error: [string \"test\"]:4: attempt to call a nil value" {
+			t.Errorf("Wrong error reported: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
So, as per @fbogsany 's [comment](https://github.com/Shopify/go-lua/pull/100#discussion_r283544031), then that's the proper fix.

The issue surfaced as follow:
```lua
local thing = barf() 	-- line 1; is the source of the error

print(thing) 		-- line 3; this won't execute, and must NOT be the loc of the error!
```
Where `barf` is a Go function registered with the VM. That function will err out and be the source of the error. Despite it being the source of the error, the next executable line (in this case line 3) would have been reported as the location of the error.

This fixes that. Also adds two tests (one for what this fixes and one that shows no regression in Lua land originating errors).