### PR TITLE
Fix format string failures in tests

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -97,7 +97,7 @@ func (d *dumpState) writeString(s string) {
 	case 4:
 		d.write(uint32(size))
 	default:
-		panic(fmt.Sprintf("unsupported pointer size (%d)"))
+		panic(fmt.Sprintf("unsupported pointer size (%d)", header.PointerSize))
 	}
 	if size > 0 {
 		d.write(ba)

--- a/go_test.go
+++ b/go_test.go
@@ -29,7 +29,7 @@ func TestIsControl(t *testing.T) {
 	for i := 0; i < 256; i++ {
 		control := i < 0x20 || i == 0x7f
 		if lib := unicode.Is(unicode.Cc, rune(i)); control != lib {
-			t.Errorf("%x: is control? %s", i, lib)
+			t.Errorf("%x: is control? %s", i, strconv.FormatBool(lib))
 		}
 	}
 }


### PR DESCRIPTION
go_test.go and dump.go failed due to errors in values provided in
format strings.  Fix both failure cases.