### PR TITLE
Nil check for prototype

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -11,9 +11,6 @@ type Frame *callInfo
 
 func (l *State) resetHookCount() { l.hookCount = l.baseHookCount }
 func (l *State) prototype(ci *callInfo) *prototype {
-	if l.stack[ci.function] == nil {
-		return nil
-	}
 	return l.stack[ci.function].(*luaClosure).prototype
 }
 func (l *State) currentLine(ci *callInfo) int {
@@ -229,11 +226,11 @@ func functionInfo(p Debug, f closure) (d Debug) {
 }
 
 func (l *State) functionName(ci *callInfo) (name, kind string) {
-	var tm tm
-	p := l.prototype(ci)
-	if p == nil {
+	if ci == &l.baseCallInfo {
 		return
 	}
+	var tm tm
+	p := l.prototype(ci)
 	pc := ci.savedPC
 	switch i := p.code[pc]; i.opCode() {
 	case opCall, opTailCall:

--- a/debug.go
+++ b/debug.go
@@ -11,10 +11,13 @@ type Frame *callInfo
 
 func (l *State) resetHookCount() { l.hookCount = l.baseHookCount }
 func (l *State) prototype(ci *callInfo) *prototype {
+	if l.stack[ci.function] == nil {
+		return nil
+	}
 	return l.stack[ci.function].(*luaClosure).prototype
 }
 func (l *State) currentLine(ci *callInfo) int {
-	return int(l.prototype(ci).lineInfo[ci.savedPC - 1])
+	return int(l.prototype(ci).lineInfo[ci.savedPC-1])
 }
 
 func chunkID(source string) string {
@@ -228,6 +231,9 @@ func functionInfo(p Debug, f closure) (d Debug) {
 func (l *State) functionName(ci *callInfo) (name, kind string) {
 	var tm tm
 	p := l.prototype(ci)
+	if p == nil {
+		return
+	}
 	pc := ci.savedPC
 	switch i := p.code[pc]; i.opCode() {
 	case opCall, opTailCall:


### PR DESCRIPTION
Currently `debug.traceback` fails with error `"An error occurred: genghis flow failed to execute with interface conversion: lua.value is nil, not *lua.luaClosure"`. This PR attempts to fix this. 

To 🎩 how `debug.traceback` will look in action once this is fixed ->

1. Go to `genghis` repo and on the terminal run `go get github.com/Shopify/go-lua@5d21fc2948423a50bfe5fbc78dc49d2025671971` (This SHA is this commit id)
2. Then run `go mod vendor` and then `dev build`
3. Go to `genghis-flows` repo and copy the binary generated (in genghis/bin/genghis) from previous step to this repo  (in .dev/binaries/genghis) by running  `cp ../genghis/bin/genghis .dev/binaries/genghis `
4. In ` genghis-flows` create a file `test_stacktrace.lua` with following code snippet: 
```
local debug = require 'debug'

function a ()
  print(debug.traceback())
  end

function b ()
  a()
end  

function c ()
  b()
end

c ()
```
5. Then create a file `test_stacktrace.json` with the path to `test_stacktrace.lua`
```
{
  "path": "test_stacktrace.lua"
}
```
6. Run `dev exec test_stacktrace.json` and see the stacktrace information.
7. The stacktrace should show something likes this:
```stack traceback:
	./platform-conditioning/test_stacktrace.lua:5: in function <./platform-conditioning/test_stacktrace.lua:3>
	./platform-conditioning/test_stacktrace.lua:13: in function <./platform-conditioning/test_stacktrace.lua:11>
	./platform-conditioning/test_stacktrace.lua:18: in function <./platform-conditioning/test_stacktrace.lua:16>
	./platform-conditioning/test_stacktrace.lua:21: in main chunk
	[Go]: in function 'require'
	[string "require "platform-conditioning.test_stacktrace"..."]:1: in main chunk
```