### PR TITLE
Update version of Golang to 1.22.1

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 name: go-lua
 
 up:
-  - go: 1.19.1
+  - go: 1.22.1
   - custom:
       name: Initializing submodules
       met?: test -f lua-tests/.git

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Shopify/go-lua
 
-go 1.19
+go 1.22


### PR DESCRIPTION
Updates Golang to 1.22.1 to use a version that includes several security fixes: https://go.dev/doc/devel/release#go1.22.1