### PR TITLE
Accept small differences in floating-point results between C & Go lua implementations

### DIFF
--- a/dump_test.go
+++ b/dump_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestUndumpThenDumpReturnsTheSameFunction(t *testing.T) {
-	_, err := exec.LookPath("luac")
+	_, err := exec.LookPath("luac5.2")
 	if err != nil {
 		t.Skipf("testing dump requires luac: %s", err)
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -46,9 +46,9 @@ func TestEmptyString(t *testing.T) {
 }
 
 func TestParserExhaustively(t *testing.T) {
-	_, err := exec.LookPath("luac")
+	_, err := exec.LookPath("luac5.2")
 	if err != nil {
-		t.Skipf("exhaustively testing the parser requires luac: %s", err)
+		t.Skipf("exhaustively testing the parser requires luac5.2: %s", err)
 	}
 	l := NewState()
 	matches, err := filepath.Glob(filepath.Join("lua-tests", "*.lua"))
@@ -73,8 +73,8 @@ func protectedTestParser(l *State, t *testing.T, source string) {
 	}()
 	t.Log("Compiling " + source)
 	binary := strings.TrimSuffix(source, ".lua") + ".bin"
-	if err := exec.Command("luac", "-o", binary, source).Run(); err != nil {
-		t.Fatalf("luac failed to compile %s: %s", source, err)
+	if err := exec.Command("luac5.2", "-o", binary, source).Run(); err != nil {
+		t.Fatalf("luac5.2 failed to compile %s: %s", source, err)
 	}
 	t.Log("Parsing " + source)
 	bin := load(l, t, binary)

--- a/parser_test.go
+++ b/parser_test.go
@@ -86,12 +86,14 @@ func protectedTestParser(l *State, t *testing.T, source string) {
 }
 
 func expectEqual(t *testing.T, x, y interface{}, m string) {
+	t.Helper()
 	if x != y {
 		t.Errorf("%s doesn't match: %v, %v\n", m, x, y)
 	}
 }
 
 func expectDeepEqual(t *testing.T, x, y interface{}, m string) bool {
+	t.Helper()
 	if reflect.DeepEqual(x, y) {
 		return true
 	}


### PR DESCRIPTION
When testing the C lua compiler (binary dump) differences, the test failed `TestParserExhaustively` in `lua-tests/attrib.lua` with `parser_test.go:134: 153: 1.0000000000000001e+33 != 1e+33`.
This is caused by different implementations of `math.Pow` in Go, and C `pow` functions.

I also replaced calls to executable `luac` with `luac5.2`; at least on recent Debian and Ubuntu versions, lua version 5.2 compiler is named so. (otherwise lua 5.4 would be used today)